### PR TITLE
formatting and linting

### DIFF
--- a/api/environment.go
+++ b/api/environment.go
@@ -60,12 +60,11 @@ func (e EnvironmentController) DeployEnvironment(c *gin.Context) {
 	prefix := ""
 	switch conf.R10k.Prefix {
 	case "mapping":
-    var err error
-    prefix, err = h.GetPrefixFromMapping(conf.RepoMapping, data.RepoName)
+		prefix, err = h.GetPrefixFromMapping(conf.RepoMapping, data.RepoName)
 
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"message": "Error getting Prefix", "error": err})
-      log.Errorf("error getting prefix from mapping: %s", err)
+			log.Errorf("error getting prefix from mapping: %s", err)
 			c.Abort()
 			return
 		}

--- a/lib/helpers/prefix.go
+++ b/lib/helpers/prefix.go
@@ -1,7 +1,7 @@
 package helpers
 
 import (
-  "fmt"
+	"fmt"
 	"github.com/voxpupuli/webhook-go/lib/parsers"
 )
 
@@ -21,10 +21,10 @@ func (h *Helper) GetPrefix(data parsers.Data, prefix string) string {
 // Lookup the repo name in the mapping and return the corresponding prefix.
 // If the repo name is not found in the mapping, it returns an empty string.
 func (h *Helper) GetPrefixFromMapping(mapping map[string]string, repoName string) (string, error) {
-  prefix, ok := mapping[repoName]
-  if ok {
-    return prefix, nil
-  } else {
-    return "", fmt.Errorf("Prefix not found in mapping for repo '%s'", repoName)
-  }
+	prefix, ok := mapping[repoName]
+	if ok {
+		return prefix, nil
+	} else {
+		return "", fmt.Errorf("Prefix not found in mapping for repo '%s'", repoName)
+	}
 }

--- a/lib/helpers/prefix_test.go
+++ b/lib/helpers/prefix_test.go
@@ -37,16 +37,16 @@ func Test_GetPrefixFromMapping(t *testing.T) {
 	}
 
 	prefix, err := h.GetPrefixFromMapping(mapping, "testrepo")
-  assert.NilError(t, err)
-  assert.Equal(t, "testprefix", prefix)
+	assert.NilError(t, err)
+	assert.Equal(t, "testprefix", prefix)
 
-  prefix, err = h.GetPrefixFromMapping(mapping, "otherrepo")
-  assert.NilError(t, err)
-  assert.Equal(t, "", prefix)
+	prefix, err = h.GetPrefixFromMapping(mapping, "otherrepo")
+	assert.NilError(t, err)
+	assert.Equal(t, "", prefix)
 
 	// Test with a repo not in the mapping
 	prefix, err = h.GetPrefixFromMapping(mapping, "nonexistentrepo")
-  assert.Error(t, err, "Prefix not found in mapping for repo 'nonexistentrepo'")
-  assert.Equal(t, "", prefix)
+	assert.Error(t, err, "Prefix not found in mapping for repo 'nonexistentrepo'")
+	assert.Equal(t, "", prefix)
 
 }


### PR DESCRIPTION
Fixed the formatting of the code and removed a shadow declaration of the `err` variable.

this will enable the merging of voxpupuli/webhook-go#202